### PR TITLE
input and output snippets

### DIFF
--- a/scanf-and-printf.json
+++ b/scanf-and-printf.json
@@ -1,0 +1,17 @@
+{
+"printf": {
+	"prefix": ["printf", "p"],
+	"body": [
+		"printf(\"%$1\", ${2://data});"
+	],
+	"description": "prints required data"
+},
+
+"scanf": {
+	"prefix": ["scanf", "s"],
+	"body": [
+		"scanf(\"%$1\", &${2://var});"
+	],
+	"description": "scans required data"
+}
+}


### PR DESCRIPTION
I've noticed vs code extensions don't contain scanf and printf code snippets even though <stdio.h> uses them. So ive created them for convenience. There is also no void function snippet available. Ill do it in the next file.